### PR TITLE
feat!: drop support for node < 14

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -8,13 +8,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x # deprecated
-          - 11.x # deprecated
-          - 12.x # maintainence ends 2022-04-30
-          - 13.x # deprecated
-          - 14.x # maintainence ends 2023-04-30
-          - 15.x # deprecated
-          - 16.x
+          - 14.x # until 2023-04-30
+          - 16.x # until 2023-09-11
+          - 18.x # until 2025-04-30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2


### PR DESCRIPTION
this probably will still work, but Jest no longer runs on those versions. If your product would like this library to support dead versions of Node, please consider becoming a paying sponsor.