### PR TITLE
ci: test on supported node versions only

### DIFF
--- a/.github/workflows/npmtest.yml
+++ b/.github/workflows/npmtest.yml
@@ -8,10 +8,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 16.x # until 2023-09-11
-          - 18.x # until 2025-04-30
-          - 19.x # until 2023-06-01
           - 20.x # until 2026-04-30
+          - 22.x # until 2027-04-30
+          - 24.x # until 2028-04-30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What was broken

The `tests` workflow has been red on every push to `main` going back to at least June 2025. Only one matrix job fails — `build (16.x)`:

```
TypeError: (0 , _nodeOs(...).availableParallelism) is not a function
    at getMaxWorkers (node_modules/jest-config/build/index.js:810:56)
    at normalize (node_modules/jest-config/build/index.js:2123:54)
    at readConfig (node_modules/jest-config/build/index.js:966:36)
```

jest 30 declares `engines.node` as `^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0` and calls `os.availableParallelism`, which landed in Node 18.14 / 19.4. Node 16 has no such function, so that job cannot pass with the currently pinned jest — it isn't a flake or a transient dependency problem.

## The fix

Update the `node-version` matrix in `.github/workflows/npmtest.yml`:

- **Dropped `16.x`** (EOL 2023-09-11) — outside jest's engines range, the actual failure.
- **Dropped `19.x`** (EOL 2023-06-01) — also outside jest's engines range; it only passed by accident because 19.4+ happens to have `availableParallelism`.
- **Dropped `18.x`** (EOL 2025-04-30) — passing today, but end-of-life.
- **Added `22.x` and `24.x`** — the current supported lines, both within jest's engines range.

`20.x` stays, matching `.tool-versions` and the `coverage` workflow.

No source or test changes; `index.js` and `__tests__/` are untouched.

## Verification

Locally on Node 22.22.2: `npm test` passes 6/6, and `npm run test:coverage` reports 100% statements/branches/functions/lines. Node 24 was not available in this environment to run directly, but it is inside jest's declared engines range. CI on this branch will cover 20.x, 22.x, and 24.x.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfALNkU1SoMFsNMvD43oVE)_